### PR TITLE
Add docstrings, convenience version of `set_coords`

### DIFF
--- a/src/Graphics.jl
+++ b/src/Graphics.jl
@@ -10,6 +10,40 @@ if isdefined(Base, :scale)
     import Base: scale
 end
 
+"""
+Graphics defines an API for drawing in two dimensions.
+
+- Geometric primitives: `Vec2`, `Point`, `BoundingBox`
+
+- Geometry API: `aspect_ratio`, `center`, `deform`, `diagonal`,
+  `isinside`, `shift`, `height`, `width`, `xmin`, `xmax`, `ymin`,
+  `ymax`, `xrange`, `yrange`
+
+- 2d drawing contexts: `GraphicsDevice`, `GraphicsContext`, `creategc`, `getgc`
+
+- Coordinate systems: `set_coords`, `reset_transform`, `rotate`,
+  `scale`, `translate`, `user_to_device!`, `device_to_user!`,
+  `user_to_device_distance!`, `device_to_user_distance!`,
+  `user_to_device`, `device_to_user`
+
+- Lines: `set_line_width`, `set_dash`
+
+- Colors and painting (drawing attributes): `set_source`,
+  `set_source_rgb`, `set_source_rgba`, `save`, `restore`
+
+- Clipping: `clip`, `clip_preserve`, `reset_clip`
+
+- Paths: `move_to`, `line_to`, `rel_line_to`, `rel_move_to`,
+  `new_path`, `new_sub_path`, `close_path`, `arc`
+
+- High-level paths: `rectangle`, `circle`, `polygon`
+
+- Fill and stroke: `fill`, `fill_preserve`, `paint`, `stroke`,
+  `stroke_preserve`, `stroke_transformed`,
+  `stroke_transformed_preserve`
+"""
+Graphics
+
 export
     # Part 1. 2D Geometry
     Vec2, Point, BoundingBox,

--- a/src/Graphics.jl
+++ b/src/Graphics.jl
@@ -242,7 +242,24 @@ function set_coords(c::GraphicsContext, x, y, w, h, l, r, t, b)
     end
     c
 end
-set_coords(c::GraphicsContext, device::BoundingBox, user::BoundingBox) = set_coords(c, device.xmin, device.ymin, width(device), height(device), user.xmin, user.xmax, user.ymin, user.ymax)
+"""
+    set_coords(c::GraphicsContext, device::BoundingBox, user::BoundingBox)
+    set_coords(c::GraphicsContext, user::BoundingBox)
+
+Set the device->user coordinate transformation of `c` so that
+`device`, expressed in "device coordinates" (pixels), is equivalent to
+`user` as expressed in "user coordinates". If `device` is omitted, it
+defaults to the full span of `c`,
+`BoundingBox(0, width(c), 0, height(c))`.
+
+See also `get_matrix`, `set_matrix`.
+"""
+set_coords(c::GraphicsContext, device::BoundingBox, user::BoundingBox) =
+    set_coords(c,
+               device.xmin, device.ymin, width(device), height(device),
+               user.xmin, user.xmax, user.ymin, user.ymax)
+set_coords(c::GraphicsContext, user::BoundingBox) =
+    set_coords(c, BoundingBox(0, width(c), 0, height(c)), user)
 
 @mustimplement save(gc::GraphicsContext)
 @mustimplement restore(gc::GraphicsContext)

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -1,0 +1,13 @@
+export set_coords
+function set_coords(c::GraphicsContext, x, y, w, h, l, r, t, b)
+    Base.depwarn("set_coords is deprecated; use set_coordinates or inner_canvas instead", :set_coords)
+    inner_canvas(c::GraphicsContext, x, y, w, h, l, r, t, b)
+end
+function set_coords(c::GraphicsContext, device::BoundingBox, user::BoundingBox)
+    Base.depwarn("set_coords is deprecated; use set_coordinates or inner_canvas instead", :set_coords)
+    inner_canvas(c::GraphicsContext, device, user)
+end
+function set_coords(c::GraphicsContext, user::BoundingBox)
+    Base.depwarn("set_coords is deprecated; use set_coordinates instead", :set_coords)
+    inner_canvas(c::GraphicsContext, BoundingBox(0, width(c), 0, height(c)), user)
+end

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,83 +1,103 @@
 using Graphics
-using Base.Test
+if VERSION >= v"0.5.0-dev+7720"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
 
-# Part 1. Geometry
+@testset "Geometry" begin
+    ## Point-vector identity (typealias)
+    @test Point(2, 1) == Vec2(2, 1)
 
-## Point-vector identity (typealias)
-@test Point(2, 1) == Vec2(2, 1)
-
-## Vector operators
-@test Vec2(1, 2) + Vec2(3, 4) == Vec2(4, 6)
-@test Vec2(1, 2) - Vec2(3, 4) == Vec2(-2, -2)
-@test Vec2(1, 2) * 1 == Vec2(1, 2) # identity
-@test Vec2(1, 2) * 0 == Vec2(0, 0) # null
-@test Vec2(1, 2) * 2 == Vec2(2, 4) # scalar multiplication
-@test Vec2(1, 2) / 2 == Vec2(0.5, 1)
+    ## Vector operators
+    @test Vec2(1, 2) + Vec2(3, 4) == Vec2(4, 6)
+    @test Vec2(1, 2) - Vec2(3, 4) == Vec2(-2, -2)
+    @test Vec2(1, 2) * 1 == Vec2(1, 2) # identity
+    @test Vec2(1, 2) * 0 == Vec2(0, 0) # null
+    @test Vec2(1, 2) * 2 == Vec2(2, 4) # scalar multiplication
+    @test Vec2(1, 2) / 2 == Vec2(0.5, 1)
 
 
-## rotation: rotate()
-@test rotate(Vec2(1, 2), π, Vec2(1, 1)).x ≈ 1
-@test rotate(Vec2(1, 2), π, Vec2(1, 1)).y ≈ 0
-@test rotate(Vec2(1, 2), 2π).x ≈ 1
-@test rotate(Vec2(1, 2), 2π).y ≈ 2
+    ## rotation: rotate()
+    @test rotate(Vec2(1, 2), π, Vec2(1, 1)).x ≈ 1
+    @test rotate(Vec2(1, 2), π, Vec2(1, 1)).y ≈ 0
+    @test rotate(Vec2(1, 2), 2π).x ≈ 1
+    @test rotate(Vec2(1, 2), 2π).y ≈ 2
 
-## Euclidean norm/magnitude: norm()
-@test norm(Vec2(1, 2)) == sqrt(5)
-@test norm(Vec2(0, 0)) == 0
+    ## Euclidean norm/magnitude: norm()
+    @test norm(Vec2(1, 2)) == sqrt(5)
+    @test norm(Vec2(0, 0)) == 0
 
-## Bounding boxes: BoundingBox
-BBT_point_1 = Vec2(1, 1)
-BBT_point_2 = Vec2(2, 3)
-BBT_point_3 = Vec2(4, 5)
-BBT = BoundingBox(BBT_point_1, BBT_point_2, BBT_point_3)
+    ## Bounding boxes: BoundingBox
+    BBT_point_1 = Vec2(1, 1)
+    BBT_point_2 = Vec2(2, 3)
+    BBT_point_3 = Vec2(4, 5)
+    BBT = BoundingBox(BBT_point_1, BBT_point_2, BBT_point_3)
 
-### BoundingBox attributes
-@test BBT == BoundingBox(1, 4, 1, 5)
-@test height(BBT) == 4
-@test width(BBT) == 3
-@test diagonal(BBT) == 5
-@test aspect_ratio(BBT) ≈ 1.333333333333
-@test xmin(BBT) == 1
-@test xmax(BBT) == 4
-@test center(BBT) == Vec2(2.5, 3)
-@test xrange(BBT) == (1, 4)
-@test yrange(BBT) == (1, 5)
+    ### BoundingBox attributes
+    @test BBT == BoundingBox(1, 4, 1, 5)
+    @test height(BBT) == 4
+    @test width(BBT) == 3
+    @test diagonal(BBT) == 5
+    @test aspect_ratio(BBT) ≈ 1.333333333333
+    @test xmin(BBT) == 1
+    @test xmax(BBT) == 4
+    @test center(BBT) == Vec2(2.5, 3)
+    @test xrange(BBT) == (1, 4)
+    @test yrange(BBT) == (1, 5)
 
-### BoundingBox operations
-BBT_1 = BoundingBox(2, 3, 4, 5)
-BBT_2 = BoundingBox(6, 7, 8, 9)
-BBT_3 = BoundingBox(NaN, NaN, NaN, NaN)
-BBT_4 = BoundingBox(-Inf, -Inf, -Inf, -Inf)
+    ### BoundingBox operations
+    BBT_1 = BoundingBox(2, 3, 4, 5)
+    BBT_2 = BoundingBox(6, 7, 8, 9)
+    BBT_3 = BoundingBox(NaN, NaN, NaN, NaN)
+    BBT_4 = BoundingBox(-Inf, -Inf, -Inf, -Inf)
 
-#### BoundingBox (+)
-@test BBT_1 + BBT_2 == BoundingBox(2, 7, 4, 9)
-@test BBT_3 + BBT_4 == BoundingBox(-Inf, -Inf, -Inf, -Inf)
+    #### BoundingBox (+)
+    @test BBT_1 + BBT_2 == BoundingBox(2, 7, 4, 9)
+    @test BBT_3 + BBT_4 == BoundingBox(-Inf, -Inf, -Inf, -Inf)
 
-#### BoundingBox (&)
-@test BBT_1 & BBT_2 == BoundingBox(6, 3, 8, 5)
-@test BBT_3 & BBT_4 == BoundingBox(-Inf, -Inf, -Inf, -Inf)
+    #### BoundingBox (&)
+    @test BBT_1 & BBT_2 == BoundingBox(6, 3, 8, 5)
+    @test BBT_3 & BBT_4 == BoundingBox(-Inf, -Inf, -Inf, -Inf)
 
-#### deform()
-@test deform(BBT_1, -1, 2, -3, 4) == BoundingBox(1, 5, 1, 9)
+    #### deform()
+    @test deform(BBT_1, -1, 2, -3, 4) == BoundingBox(1, 5, 1, 9)
 
-#### shift()
-@test shift(BBT_1, -1, 2) == BoundingBox(1, 2, 6, 7)
+    #### shift()
+    @test shift(BBT_1, -1, 2) == BoundingBox(1, 2, 6, 7)
 
-#### scale()
-@test BBT_1 * 3 == BoundingBox(1, 4, 3, 6)
+    #### scale()
+    @test BBT_1 * 3 == BoundingBox(1, 4, 3, 6)
 
-#### rotate()
-BBT_3 = rotate(BBT_1, π, Point(0, 1))
-@test BBT_3.xmin ≈ -3
-@test BBT_3.ymin ≈ -3
-@test BBT_3.xmax ≈ -2
-@test BBT_3.ymax ≈ -2
+    #### rotate()
+    BBT_3 = rotate(BBT_1, π, Point(0, 1))
+    @test BBT_3.xmin ≈ -3
+    @test BBT_3.ymin ≈ -3
+    @test BBT_3.xmax ≈ -2
+    @test BBT_3.ymax ≈ -2
 
-#### with_aspect_ratio()
-@test with_aspect_ratio(BBT_1, 2) == BoundingBox(2.25, 2.75, 4, 5)
-@test with_aspect_ratio(BBT_1, 0.5) == BoundingBox(2, 3, 4.25, 4.75)
+    #### with_aspect_ratio()
+    @test with_aspect_ratio(BBT_1, 2) == BoundingBox(2.25, 2.75, 4, 5)
+    @test with_aspect_ratio(BBT_1, 0.5) == BoundingBox(2, 3, 4.25, 4.75)
 
-#### isinside()
-@test isinside(BBT_1, Point(2.5, 4.5))
-@test isinside(BBT_1, Point(2, 4))
-@test isinside(BBT_1, Point(1, 3)) == false
+    #### isinside()
+    @test isinside(BBT_1, Point(2.5, 4.5))
+    @test isinside(BBT_1, Point(2, 4))
+    @test isinside(BBT_1, Point(1, 3)) == false
+end
+
+# using Gtk.ShortNames, Cairo
+
+# @testset "Canvas" begin
+#     win = Window() |> (cnvs = Canvas(300, 280))
+#     draw(cnvs) do c
+#         set_coords(getgc(cnvs), BoundingBox(0, 1, 0, 1))
+#     end
+#     showall(win)
+#     sleep(0.5)
+#     mtrx = Cairo.get_matrix(getgc(cnvs))
+#     @test mtrx.xx == 300
+#     @test mtrx.yy == 280
+#     @test mtrx.xy == mtrx.yx == mtrx.x0 == mtrx.y0 == 0
+# end


### PR DESCRIPTION
CC @lobingera (partially fixes https://github.com/JuliaGraphics/Cairo.jl/issues/180).

I added the first test of `set_coords`, but then I decided that I wasn't sure I wanted to make testing of this package dependent on Gtk. So I commented it out. Thoughts welcome.