### PR TITLE
Add dependency on NaNMath for IEEE min/max

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Colors
 Compat 0.17.0
+NaNMath 0.2.4


### PR DESCRIPTION
This replaces the changes made in #9 with the equivalent functions now defined in NaNMath.