### PR TITLE
Docs: add preview and set meta prior to makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
 using Documenter
 using Graphics
 
+DocMeta.setdocmeta!(Graphics, :DocTestSetup, :(using Graphics); recursive=true)
+
 makedocs(
     sitename = "Graphics",
     format = Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"),
@@ -10,8 +12,7 @@ makedocs(
     checkdocs = :exports
 )
 
-DocMeta.setdocmeta!(Graphics, :DocTestSetup, :(using Graphics); recursive=true)
-
 deploydocs(
-    repo = "github.com/JuliaGraphics/Graphics.jl.git"
+    repo = "github.com/JuliaGraphics/Graphics.jl.git",
+    push_preview = true
 )


### PR DESCRIPTION
This fixes doc errors on the first run in a session.
The current implementation works fine in later runs,
but when we build to deploy there is only one run.

This also turns on previews.