### PR TITLE
add cubic curves

### DIFF
--- a/src/Graphics.jl
+++ b/src/Graphics.jl
@@ -723,7 +723,7 @@ See also: [`rel_line_to`](@ref).
 @mustimplement line_to(gc::GraphicsContext, ::Real, ::Real)
 
 """
-curve_to(gc::GraphicsContext, c1x, c1y, c2x, c2y, x, y)
+    curve_to(gc::GraphicsContext, c1x, c1y, c2x, c2y, x, y)
 
 Add a cubic bezier curve to the path. The control points will be the current point, `(c1x, c1y)`, `(c2x, c2y)` and `(x, y)`. The current point will be moved to `(x, y)`.
 
@@ -732,7 +732,7 @@ See also: [`rel_curve_to`](@ref).
 @mustimplement curve_to(gc::GraphicsContext, ::Real, ::Real, ::Real, ::Real, ::Real, ::Real)
 
 """
-rel_curve_to(gc::GraphicsContex, Δc1x, Δc1y, Δc2x, Δc2y, Δx, Δy)
+    rel_curve_to(gc::GraphicsContex, Δc1x, Δc1y, Δc2x, Δc2y, Δx, Δy)
 
 Add a cubic bezier curve to the path. The control points will be the current point `(x, y)` and `(x, y) + [(Δc1x, Δc1y), (Δc2x, Δc2y), (Δx, Δy)]`. The current point will be moved to `(x + Δx, y + Δy)`.
 

--- a/src/Graphics.jl
+++ b/src/Graphics.jl
@@ -29,7 +29,7 @@ Graphics defines an API for drawing in two dimensions.
 
 - Clipping: `clip`, `clip_preserve`, `reset_clip`, `inner_canvas`
 
-- Paths: `move_to`, `line_to`, `rel_line_to`, `rel_move_to`,
+- Paths: `move_to`, `line_to`, `curve_to`, `rel_curve_to`, `rel_line_to`, `rel_move_to`,
   `new_path`, `new_sub_path`, `close_path`, `arc`
 
 - High-level paths: `rectangle`, `circle`, `polygon`
@@ -71,7 +71,7 @@ export
     clip, clip_preserve, reset_clip, inner_canvas,
 
     # path primitives
-    move_to, line_to, rel_line_to, rel_move_to, new_path, new_sub_path,
+    move_to, line_to, curve_to, rel_curve_to, rel_line_to, rel_move_to, new_path, new_sub_path,
     close_path, arc,
 
     # fill and stroke
@@ -721,6 +721,24 @@ The current point will be moved to `(x, y)`.
 See also: [`rel_line_to`](@ref).
 """
 @mustimplement line_to(gc::GraphicsContext, ::Real, ::Real)
+
+"""
+curve_to(gc::GraphicsContext, c1x, c1y, c2x, c2y, x, y)
+
+Add a cubic bezier curve to the path. The control points will be the current point, `(c1x, c1y)`, `(c2x, c2y)` and `(x, y)`. The current point will be moved to `(x, y)`.
+
+See also: [`rel_curve_to`](@ref).
+"""
+@mustimplement curve_to(gc::GraphicsContext, ::Real, ::Real, ::Real, ::Real, ::Real, ::Real)
+
+"""
+rel_curve_to(gc::GraphicsContex, Δc1x, Δc1y, Δc2x, Δc2y, Δx, Δy)
+
+Add a cubic bezier curve to the path. The control points will be the current point `(x, y)` and `(x, y) + [(Δc1x, Δc1y), (Δc2x, Δc2y), (Δx, Δy)]`. The current point will be moved to `(x + Δx, y + Δy)`.
+
+See also: [`curve_to`](@ref).
+"""
+@mustimplement rel_curve_to(gc::GraphicsContext, ::Real, ::Real, ::Real, ::Real, ::Real, ::Real)
 
 """
     rel_move_to(gc::GraphicsContext, Δx, Δy)


### PR DESCRIPTION
Bézier curves are part of most graphics/rendering interfaces, so they should be supported by Graphics.jl.
This adds Cairo.jl's `curve_to` and `rel_curve_to` to the path interface. Cairo.jl would then need to be adjusted to import these.